### PR TITLE
Do not fail tests ultimately after first test error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.artsok</groupId>
     <artifactId>rerunner-jupiter</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>Reunner-Jupiter</name>
     <description>
         JUnit 5 Extension point which rerun failed tests certain number of times

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
+                <configuration>
+                    <properties>
+                        <excludeTags>programmatic-tests</excludeTags>
+                    </properties>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>

--- a/src/test/java/io/github/artsok/ReRunnerTest.java
+++ b/src/test/java/io/github/artsok/ReRunnerTest.java
@@ -2,13 +2,25 @@ package io.github.artsok;
 
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 
 
 /**
@@ -17,53 +29,74 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Artem Sokovets
  */
 @Slf4j
-class ReRunnerTest {
-
+public class ReRunnerTest {
     private ThreadLocalRandom random = ThreadLocalRandom.current();
 
+    @ProgrammaticTest
     @RepeatedIfExceptionsTest(repeats = 2)
-    void runTest() {
+    public void runTest() {
         assertTrue(true, "No exception, repeat one time");
+    }
+
+    @Test
+    void runRunTest() throws Exception {
+        assertTestResults("runTest", true, 1, 0, 0);
     }
 
     /**
      * Repeated three times if test failed.
      * By default Exception.class will be handled in test
      */
-    @Disabled
+    @ProgrammaticTest
     @RepeatedIfExceptionsTest(repeats = 3)
-    void reRunTest() throws IOException {
+    public void reRunTest() throws IOException {
         throw new IOException("Error in Test");
+    }
+
+    @Test
+    void runReRunTest() throws Exception {
+        assertTestResults("reRunTest", false, 3, 2, 0);
     }
 
     /**
      * Repeated two times if test failed. Set IOException.class that will be handled in test
+     *
      * @throws IOException - error if occurred
      */
-    @Disabled
+    @ProgrammaticTest
     @RepeatedIfExceptionsTest(repeats = 2, exceptions = IOException.class)
-    void reRunTest2() throws IOException {
+    public void reRunTest2() throws IOException {
         throw new IOException("Exception in I/O operation");
+    }
+
+    @Test
+    void runReRun2Test() throws Exception {
+        assertTestResults("reRunTest2", false, 2, 1, 0);
     }
 
     /**
      * Repeated ten times if test failed. Set IOException.class that will be handled in test
      * Set formatter for test. Like behavior as at {@link org.junit.jupiter.api.RepeatedTest}
+     *
      * @throws IOException - error if occurred
      */
-    @Disabled
+    @ProgrammaticTest
     @RepeatedIfExceptionsTest(repeats = 10, exceptions = IOException.class,
             name = "Rerun failed test. Attempt {currentRepetition} of {totalRepetitions}")
-    void reRunTest3() throws IOException {
+    public void reRunTest3() throws IOException {
         throw new IOException("Exception in I/O operation");
     }
 
-    @Disabled
+    @Test
+    void runReRun3Test() throws Exception {
+        assertTestResults("reRunTest3", false, 10, 9, 0);
+    }
+
     @DisplayName("Name for our test")
     @RepeatedIfExceptionsTest(repeats = 105, exceptions = RuntimeException.class,
             name = "Rerun failed Test. Repetition {currentRepetition} of {totalRepetitions}")
     void reRunTest4() throws IOException {
-        if(random.nextInt() % 2 == 0) { //Исключение бросается рандомно
+        if (random.nextInt() % 2 == 0) { //Исключение бросается рандомно
             throw new RuntimeException("Error in Test");
         }
     }
@@ -72,33 +105,76 @@ class ReRunnerTest {
      * Repeated 100 times with minimum success four times, then disabled all remaining repeats.
      * See image below how it works. Default exception is Exception.class
      */
-    @Disabled
+    @ProgrammaticTest
     @DisplayName("Test Case Name")
     @RepeatedIfExceptionsTest(repeats = 100, minSuccess = 4)
-    void reRunTest5() {
-        if(random.nextInt() % 2 == 0) {
+    public void reRunTest5() {
+        if (random.nextInt() % 2 == 0) {
             throw new RuntimeException("Error in Test");
         }
     }
 
-    //    @Disabled
+    @ProgrammaticTest
     @DisplayName("Do not ultimately fail a test if there are still enough repetitions possible.")
     @RepeatedIfExceptionsTest(repeats = 2)
-    void reRunTest6() {
+    public void reRunTest6() {
         throw new RuntimeException("Error in Test");
     }
 
-    //    @Disabled
+    @Test
+    void runReRunTest6() throws Exception {
+        assertTestResults("reRunTest6", false, 2, 1, 0);
+    }
+
+    @ProgrammaticTest
     @DisplayName("Stop repetitions if 'minSuccess' cannot be reached anymore")
     @RepeatedIfExceptionsTest(repeats = 10, minSuccess = 4)
-    void reRunTest7() {
+    public void reRunTest7() {
         throw new RuntimeException("Error in Test");
     }
 
-    //    @Disabled
+    @Test
+    void runReRunTest7() throws Exception {
+        assertTestResults("reRunTest7", false, 7, 6, 3);
+    }
+
+    @ProgrammaticTest
     @DisplayName("Ultimately fail a test as soon as an unrepeatable exception occurs.")
     @RepeatedIfExceptionsTest(repeats = 2, exceptions = NumberFormatException.class)
-    void reRunTest8() {
+    public void reRunTest8() {
         throw new RuntimeException("Error in Test");
+    }
+
+    @Test
+    void runReRunTest8() throws Exception {
+        assertTestResults("reRunTest8", false, 1, 0, 0);
+    }
+
+    private void assertTestResults(String methodName, boolean successfulTestRun, int startedTests, int abortedTests,
+                                   int skippedTests) throws Exception {
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectMethod(getClass(), getClass().getMethod(methodName)))
+                .build();
+        Launcher launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+
+        if (successfulTestRun) {
+            assertEquals(1, listener.getSummary().getTestsSucceededCount(), "successful test runs");
+            assertEquals(0, listener.getSummary().getTestsFailedCount(), "failed test runs");
+        } else {
+            assertEquals(0, listener.getSummary().getTestsSucceededCount(), "successful test runs");
+            assertEquals(1, listener.getSummary().getTestsFailedCount(), "failed test runs");
+        }
+        assertEquals(startedTests, listener.getSummary().getTestsStartedCount(), "started test runs");
+        assertEquals(abortedTests, listener.getSummary().getTestsAbortedCount(), "aborted test runs");
+        assertEquals(skippedTests, listener.getSummary().getTestsSkippedCount(), "skipped test runs");
+    }
+
+    @Tag("programmatic-tests")
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ProgrammaticTest {
     }
 }

--- a/src/test/java/io/github/artsok/ReRunnerTest.java
+++ b/src/test/java/io/github/artsok/ReRunnerTest.java
@@ -23,7 +23,7 @@ class ReRunnerTest {
 
     @RepeatedIfExceptionsTest(repeats = 2)
     void runTest() {
-        assertTrue(true, () -> "No exception, repeat one time");
+        assertTrue(true, "No exception, repeat one time");
     }
 
     /**
@@ -96,8 +96,8 @@ class ReRunnerTest {
     }
 
     //    @Disabled
-    @DisplayName("Do not ultimately fail a test if there are still enough repetitions possible.")
-    @RepeatedIfExceptionsTest(repeats = 10, exceptions = NumberFormatException.class)
+    @DisplayName("Ultimately fail a test as soon as an unrepeatable exception occurs.")
+    @RepeatedIfExceptionsTest(repeats = 2, exceptions = NumberFormatException.class)
     void reRunTest8() {
         throw new RuntimeException("Error in Test");
     }

--- a/src/test/java/io/github/artsok/ReRunnerTest.java
+++ b/src/test/java/io/github/artsok/ReRunnerTest.java
@@ -80,4 +80,25 @@ class ReRunnerTest {
             throw new RuntimeException("Error in Test");
         }
     }
+
+    //    @Disabled
+    @DisplayName("Do not ultimately fail a test if there are still enough repetitions possible.")
+    @RepeatedIfExceptionsTest(repeats = 2)
+    void reRunTest6() {
+        throw new RuntimeException("Error in Test");
+    }
+
+    //    @Disabled
+    @DisplayName("Stop repetitions if 'minSuccess' cannot be reached anymore")
+    @RepeatedIfExceptionsTest(repeats = 10, minSuccess = 4)
+    void reRunTest7() {
+        throw new RuntimeException("Error in Test");
+    }
+
+    //    @Disabled
+    @DisplayName("Do not ultimately fail a test if there are still enough repetitions possible.")
+    @RepeatedIfExceptionsTest(repeats = 10, exceptions = NumberFormatException.class)
+    void reRunTest8() {
+        throw new RuntimeException("Error in Test");
+    }
 }


### PR DESCRIPTION
Hi @artsok,

I tried to fix the issue #8 with this pull request. The solution was inspired by @mkobit's solution described in https://stackoverflow.com/a/46207476. More precisely, I changed the repetition logic to abort a failed test rather than failing it as long as there are enough repetitions left that allow to reach the `minSuccess` count.

Moreover, I needed to do a bit of refactoring and tried to run the tests programmatically instead of manually (by removing the `@Disabled` annotation).

I am looking forward to your feedback and hope to get the feature released as soon as possible as it it is crucial for any CI/CD automation.

Best regards