### PR TITLE
Annotations on method level only

### DIFF
--- a/src/main/java/io/github/artsok/ParameterizedRepeatedIfExceptionsTest.java
+++ b/src/main/java/io/github/artsok/ParameterizedRepeatedIfExceptionsTest.java
@@ -20,7 +20,7 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
  *
  * @author Artem Sokovets
  */
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @ExtendWith(ParameterizedRepeatedExtension.class)

--- a/src/main/java/io/github/artsok/RepeatedIfExceptionsTest.java
+++ b/src/main/java/io/github/artsok/RepeatedIfExceptionsTest.java
@@ -27,7 +27,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @ExtendWith(RepeatIfExceptionsExtension.class)


### PR DESCRIPTION
- Removed 'TYPE' target for test annotations

Since the annotation works on method level only, it should only be usable on methods as well.
This complies with the junit @Test annotation, which cannot target classes either.
@Test can target annotations though (ElementType.ANNOTATION_TYPE), maybe this should be added.
